### PR TITLE
Admins can act on behalf of users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,45 @@
 class Admin::UsersController < ApplicationController
   def index
-    @users = User.all
+    @users = User.where(role: 0)
   end
+
+  def edit
+    @user = User.find(params[:user_id])
+    if request.env['PATH_INFO'] == "/admin/users/#{@user.id}/profile/edit"
+      @profile_change = true
+    else
+      @profile_change = false
+    end
+  end
+
+  def update
+    @user = User.find(params[:user_id])
+    if request.env['PATH_INFO'] == "/admin/users/#{@user.id}/profile"
+      @user.update(user_params)
+      if @user.save
+        flash[:success] = "#{@user.name}'s' profile has been updated."
+        redirect_to '/admin/users'
+      else
+        flash.now[:error] = @user.errors.full_messages.to_sentence
+        @profile_change = true
+        render :edit
+      end
+    else request.env['PATH_INFO'] == "/admin/users/#{@user.id}/password"
+      @user.update(password_params)
+      if @user.save
+        flash[:success] = "#{@user.name}'s password has been updated."
+        redirect_to '/admin/users'
+      end
+    end
+  end
+
+  private
+
+    def user_params
+      params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
+    end
+
+    def password_params
+      params.permit(:password, :password_confirmation)
+    end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -33,6 +33,17 @@ class Admin::UsersController < ApplicationController
     end
   end
 
+  def change_role
+    user = User.find(params[:user_id])
+    if request.env['PATH_INFO'] == "/users/#{user.id}/upgrade_to_merchant_employee"
+      user.update_column(:role, 1)
+      redirect_to '/admin/users'
+    else request.env['PATH_INFO'] == "/users/#{user.id}/upgrade_to_merchant_admin"
+      user.update_column(:role, 2)
+      redirect_to '/admin/users'
+    end
+  end
+
   private
 
     def user_params

--- a/app/views/admin/users/_edit_password.html.erb
+++ b/app/views/admin/users/_edit_password.html.erb
@@ -1,0 +1,13 @@
+<h1>Edit Password</h1>
+
+<%= form_tag path, method: method do %>
+
+<%= label_tag :password %>
+<%= password_field_tag :password %>
+
+<%= label_tag :password_confirmation %>
+<%= password_field_tag :password_confirmation %>
+
+<%= submit_tag button %>
+
+<% end %>

--- a/app/views/admin/users/_edit_profile.html.erb
+++ b/app/views/admin/users/_edit_profile.html.erb
@@ -1,0 +1,25 @@
+<h1>Edit Profile</h1>
+
+<%= form_tag path, method: method do %>
+
+  <%= label_tag :name %>
+  <%= text_field_tag :name, @user.name %>
+
+  <%= label_tag :address %>
+  <%= text_field_tag :address, @user.address %>
+
+  <%= label_tag :city %>
+  <%= text_field_tag :city, @user.city %>
+
+  <%= label_tag :state %>
+  <%= text_field_tag :state, @user.state %>
+
+  <%= label_tag :zip %>
+  <%= text_field_tag :zip, @user.zip %>
+
+  <%= label_tag :email %>
+  <%= text_field_tag :email, @user.email %>
+
+  <%= submit_tag button %>
+
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,5 @@
+<% if @profile_change == true %>
+  <%= render partial: "edit_profile", locals: {path: "/admin/users/#{@user.id}/profile", method: :patch, button: "Update #{@user.name}'s Profile"} %>
+<% elsif @profile_change == false %>
+  <%= render partial: "edit_password", locals: {path: "/admin/users/#{@user.id}/password", method: :patch, button: "Update #{@user.name}'s Password"} %>
+<% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -10,5 +10,7 @@
     <%= user.email %>
     <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
     <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
+    <%= link_to "Upgrade #{user.name} to Merchant Employee", "/admin/users/#{user.id}/upgrade_to_merchant_employee" %>
+    <%= link_to "Upgrade #{user.name} to Merchant Admin", "/admin/users/#{user.id}/upgrade_to_merchant_admin" %>
   </section>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,14 @@
+<h1>All Default Users</h1>
+
+<% @users.each do |user| %>
+  <section id= 'user-<%=user.id%>'>
+    <%= user.name %>
+    <%= user.city %>
+    <%= user.state %>
+    <%= user.address %>
+    <%= user.zip %>
+    <%= user.email %>
+    <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
+    <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
+  </section>
+<% end %>

--- a/app/views/users/_edit_password.html.erb
+++ b/app/views/users/_edit_password.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit Your Password</h1>
+<h1>Edit Password</h1>
 
 <%= form_tag path, method: method do %>
 

--- a/app/views/users/_edit_profile.html.erb
+++ b/app/views/users/_edit_profile.html.erb
@@ -1,6 +1,6 @@
-<h1>Edit Your Profile</h1>
+<h1>Edit Profile</h1>
 
-<%= form_tag '/profile', method: :patch do %>
+<%= form_tag path, method: method do %>
 
   <%= label_tag :name %>
   <%= text_field_tag :name, @user.name %>
@@ -20,6 +20,6 @@
   <%= label_tag :email %>
   <%= text_field_tag :email, @user.email %>
 
-  <%= submit_tag 'Update Profile' %>
+  <%= submit_tag button %>
 
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <% if @profile_change == true %>
-  <%= render partial: "edit_profile", locals: {path: '/profile', method: :patch, button: 'Update Profile'} %>
+  <%= render partial: "edit_profile", locals: {path: '/profile', method: :patch, button: 'Update My Profile'} %>
 <% elsif @profile_change == false %>
   <%= render partial: "edit_password", locals: {path: '/profile/password', method: :patch, button: 'Update My Password'} %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,5 +61,7 @@ Rails.application.routes.draw do
     patch '/users/:user_id/profile', to: "users#update"
     get '/users/:user_id/password/edit', to: "users#edit"
     patch 'users/:user_id/password', to: "users#update"
+    get '/users/:user_id/upgrade_to_merchant_employee', to: "users#change_role"
+    get '/users/:user_id/upgrade_to_merchant_admin', to: "users#change_role"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   get "/cart", to: "cart#show"
   delete "/cart", to: "cart#empty"
   delete "/cart/:item_id", to: "cart#remove_item"
-  
+
   delete "/cart/:item_id/quantity", to: "cart#remove_item_quantity"
 
   get "/orders/new", to: "orders#new"
@@ -57,5 +57,9 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/', to: "admins#show"
     get '/users', to: "users#index"
+    get '/users/:user_id/profile/edit', to: "users#edit"
+    patch '/users/:user_id/profile', to: "users#update"
+    get '/users/:user_id/password/edit', to: "users#edit"
+    patch 'users/:user_id/password', to: "users#update"
   end
 end

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'admin can perform the same actions that a user can and also chan
                             password: "user1",
                             password_confirmation: "user1")
 
-      merchant_admin = User.create!(name: "Merchant Admin",
+      merchant_admin = User.create!(name: "Ima M. Admin",
                                     address: "1230 East Street",
                                     city: "Boulder",
                                     state: "CO",
@@ -101,6 +101,52 @@ RSpec.describe 'admin can perform the same actions that a user can and also chan
 
       expect(current_path).to eq('/admin/users')
       expect(page).to have_content("#{user_1.name}'s password has been updated.")
+    end
+
+    it "I can upgrade a default user to a merchant by changing their role" do
+      admin = User.create!(name: "Admin",
+                          address: "1230 East Street",
+                          city: "Boulder", state: "CO",
+                          zip: 98273,
+                          email: "admin@admin.com",
+                          password: "admin",
+                          password_confirmation: "admin", role: 3)
+
+      user_1 = User.create!(name: "User 1",
+                            address: "User 1 Street",
+                            city: "Denver",
+                            state: "CO",
+                            zip: 80207,
+                            email: "user1@user.com",
+                            password: "user1",
+                            password_confirmation: "user1")
+
+      user_2 = User.create!(name: "User 2",
+                            address: "User 2 Street",
+                            city: "Denver",
+                            state: "CO",
+                            zip: 80207,
+                            email: "user2@user.com",
+                            password: "user2",
+                            password_confirmation: "user2")
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit '/admin/users'
+
+      within "#user-#{user_1.id}" do
+        click_link("Upgrade #{user_1.name} to Merchant Employee")
+      end
+
+      expect(current_path).to eq('/admin/users')
+      expect(page).to_not have_css("#user-#{user_1.id}")
+
+      within "#user-#{user_2.id}" do
+        click_link("Upgrade #{user_2.name} to Merchant Admin")
+      end
+
+      expect(current_path).to eq('/admin/users')
+      expect(page).to_not have_css("#user-#{user_2.id}")
     end
   end
 end

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe 'admin can perform the same actions that a user can and also change their role to merchant' do
+  describe 'as an admin I can access an index of all default users' do
+    it "I can edit a default user's profile" do
+      admin = User.create!(name: "Admin",
+                          address: "1230 East Street",
+                          city: "Boulder", state: "CO",
+                          zip: 98273,
+                          email: "admin@admin.com",
+                          password: "admin",
+                          password_confirmation: "admin", role: 3)
+
+      user_1 = User.create!(name: "User 1",
+                            address: "User 1 Street",
+                            city: "Denver",
+                            state: "CO",
+                            zip: 80207,
+                            email: "user1@user.com",
+                            password: "user1",
+                            password_confirmation: "user1")
+
+      merchant_admin = User.create!(name: "Merchant Admin",
+                                    address: "1230 East Street",
+                                    city: "Boulder",
+                                    state: "CO",
+                                    zip: 98273,
+                                    email: "merchant_admin@merchant_admin.com",
+                                    password: "merchant_admin",
+                                    password_confirmation: "merchant_admin", role: 2)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit '/'
+
+      within 'nav' do
+        click_link "See All Users"
+      end
+
+      expect(current_path).to eq('/admin/users')
+      expect(page).to_not have_content(merchant_admin.name)
+
+      within "#user-#{user_1.id}" do
+        click_link("Edit #{user_1.name}'s Profile")
+      end
+
+      expect(current_path).to eq("/admin/users/#{user_1.id}/profile/edit")
+
+      expect(find_field(:name).value).to eq "User 1"
+      expect(find_field(:address).value).to eq "User 1 Street"
+      expect(find_field(:city).value).to eq "Denver"
+      expect(find_field(:state).value).to eq "CO"
+      expect(find_field(:zip).value).to eq "80207"
+      expect(find_field(:email).value).to eq "user1@user.com"
+
+      fill_in :name, with: "Changed Name"
+      fill_in :address, with: "Changed Address"
+      click_button "Update #{user_1.name}'s Profile"
+
+      expect(current_path).to eq('/admin/users')
+      within "#user-#{user_1.id}" do
+        expect(page).to have_content("Changed Name")
+        expect(page).to_not have_content("User 1")
+      end
+    end
+
+    it "I can edit a default user's password" do
+      admin = User.create!(name: "Admin",
+                          address: "1230 East Street",
+                          city: "Boulder", state: "CO",
+                          zip: 98273,
+                          email: "admin@admin.com",
+                          password: "admin",
+                          password_confirmation: "admin", role: 3)
+
+      user_1 = User.create!(name: "User 1",
+                            address: "User 1 Street",
+                            city: "Denver",
+                            state: "CO",
+                            zip: 80207,
+                            email: "user1@user.com",
+                            password: "user1",
+                            password_confirmation: "user1")
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit '/admin/users'
+
+      within "#user-#{user_1.id}" do
+        click_link("Edit #{user_1.name}'s Password")
+      end
+
+      expect(current_path).to eq("/admin/users/#{user_1.id}/password/edit")
+
+      password = "newpasswordforuser"
+      password_confirmation = "newpasswordforuser"
+
+      fill_in :password, with: password
+      fill_in :password_confirmation, with: password_confirmation
+      click_button "Update #{user_1.name}'s Password"
+
+      expect(current_path).to eq('/admin/users')
+      expect(page).to have_content("#{user_1.name}'s password has been updated.")
+    end
+  end
+end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'User profile page' do
     fill_in :city, with: "Different City"
     fill_in :state, with: "TX"
     fill_in :zip, with: 70291
-    click_button "Update Profile"
+    click_button "Update My Profile"
 
     expect(current_path).to eq('/profile')
     expect(page).to have_content("Your profile has been updated.")
@@ -52,7 +52,7 @@ RSpec.describe 'User profile page' do
 
     click_link "Edit your profile"
     fill_in :name, with: "Changed my name again"
-    click_button "Update Profile"
+    click_button "Update My Profile"
 
     expect(current_path).to eq('/profile')
     expect(page).to have_content("Changed my name again")
@@ -129,7 +129,7 @@ RSpec.describe 'User profile page' do
     fill_in :state, with: "TX"
     fill_in :zip, with: 70291
     fill_in :email, with: "another_user@user.com"
-    click_button "Update Profile"
+    click_button "Update My Profile"
 
     expect(current_path).to eq('/profile')
     expect(page).to have_content('Email has already been taken')


### PR DESCRIPTION
* Add tests and functionality that an admin can edit a user's profile, edit a user's password, and upgrade them to either a merchant employee or merchant admin
* I tried implementing flash messages when an admin changes a default user's role (Ex: "User has been upgraded to merchant employee), but for some reason, the flash messages weren't displaying properly. I tested the functionality of the admin changing a default user's role multiple times in development by logging in and out as both the admin and user, and the functionality is all working properly. The only issue is that the flash messages aren't displaying. Since the flash messages weren't required, I'll only add them later if I have time.
* All tests passing except the order creation ones that were skipped when I pulled down master