### PR TITLE
Admin user management

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < Admin::BaseController
   def index
-    @users = User.where(role: 0)
+    @users = User.all
   end
 
   def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -39,12 +39,11 @@ class Admin::UsersController < Admin::BaseController
 
   def change_role
     user = User.find(params[:user_id])
-    require "pry"; binding.pry
-    if request.env['PATH_INFO'] == "admin/users/#{user.id}/upgrade_to_merchant_employee"
-      user.update_column(:role, 1)
+    if request.env['PATH_INFO'] == "/admin/users/#{user.id}/upgrade_to_merchant_employee"
+      user.update(role: 1)
       redirect_to '/admin/users'
     else request.env['PATH_INFO'] == "/users/#{user.id}/upgrade_to_merchant_admin"
-      user.update_column(:role, 2)
+      user.update(role: 2)
       redirect_to '/admin/users'
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -39,7 +39,8 @@ class Admin::UsersController < Admin::BaseController
 
   def change_role
     user = User.find(params[:user_id])
-    if request.env['PATH_INFO'] == "/users/#{user.id}/upgrade_to_merchant_employee"
+    require "pry"; binding.pry
+    if request.env['PATH_INFO'] == "admin/users/#{user.id}/upgrade_to_merchant_employee"
       user.update_column(:role, 1)
       redirect_to '/admin/users'
     else request.env['PATH_INFO'] == "/users/#{user.id}/upgrade_to_merchant_admin"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,7 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find(params[:user_id])
   end
 
   def edit

--- a/app/views/admin/admins/show.html.erb
+++ b/app/views/admin/admins/show.html.erb
@@ -4,7 +4,7 @@
   <h2>Packaged:</h2>
   <% @orders.status("packaged").each do |order| %>
   <div id="order-<%= order.id %>">
-    <%= link_to "#{order.name}", "admin/users/#{order.user.id}/profile" %>
+    <%= link_to "#{order.name}", "admin/users/#{order.user.id}" %>
     <%= order.id %>
     <%= order.created_at.strftime('%m/%d/%Y') %>
     <%= link_to "Ship Order", "admin/orders/#{order.id}", method: :patch %>
@@ -16,7 +16,7 @@
   <h2>Pending:</h2>
   <% @orders.status("pending").each do |order| %>
     <div id="order-<%= order.id %>">
-      <%= link_to "#{order.name}", "admin/users/#{order.user.id}/profile" %>
+      <%= link_to "#{order.name}", "admin/users/#{order.user.id}" %>
       <%= order.id %>
       <%= order.created_at.strftime('%m/%d/%Y') %>
     </div>
@@ -27,7 +27,7 @@
   <h2>Shipped:</h2>
   <% @orders.status("shipped").each do |order| %>
   <div id="order-<%= order.id %>">
-    <%= link_to "#{order.name}", "admin/users/#{order.user.id}/profile" %>
+    <%= link_to "#{order.name}", "admin/users/#{order.user.id}" %>
     <%= order.id %>
     <%= order.created_at.strftime('%m/%d/%Y') %>
   </div>
@@ -38,7 +38,7 @@
   <h2>Cancelled:</h2>
   <% @orders.status("cancelled").each do |order| %>
   <div id="order-<%= order.id %>">
-    <%= link_to "#{order.name}", "admin/users/#{order.user.id}/profile" %>
+    <%= link_to "#{order.name}", "admin/users/#{order.user.id}" %>
     <%= order.id %>
     <%= order.created_at %>
   </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,8 +5,10 @@
     <%= link_to "#{user.name}", "admin/users/#{user.id}" %>
     Registered: <%= user.created_at %>
     User Type: <%= user.role %>
-    <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
-    <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
+    <% if user.role != "admin" %>
+      <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
+      <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
+    <% end %>
     <% if user.role == "user" %>
       <%= link_to "Upgrade #{user.name} to Merchant Employee", "/admin/users/#{user.id}/upgrade_to_merchant_employee" %>
       <%= link_to "Upgrade #{user.name} to Merchant Admin", "/admin/users/#{user.id}/upgrade_to_merchant_admin" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @users.each do |user| %>
   <section id='user-<%=user.id%>'>
-    <%= link_to "#{user.name}", "admin/users/#{user.id}" %>
+    <%= link_to "#{user.name}", "/users/#{user.id}" %>
     Registered: <%= user.created_at %>
     User Type: <%= user.role %>
     <% if user.role != "admin" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,9 +5,9 @@
     <%= link_to "#{user.name}", "admin/users/#{user.id}" %>
     Registered: <%= user.created_at %>
     User Type: <%= user.role %>
+    <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
+    <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
     <% if user.role == "user" %>
-      <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
-      <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
       <%= link_to "Upgrade #{user.name} to Merchant Employee", "/admin/users/#{user.id}/upgrade_to_merchant_employee" %>
       <%= link_to "Upgrade #{user.name} to Merchant Admin", "/admin/users/#{user.id}/upgrade_to_merchant_admin" %>
     <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,16 +1,15 @@
-<h1>All Default Users</h1>
+<h1>All Users</h1>
 
 <% @users.each do |user| %>
-  <section id= 'user-<%=user.id%>'>
-    <%= user.name %>
-    <%= user.city %>
-    <%= user.state %>
-    <%= user.address %>
-    <%= user.zip %>
-    <%= user.email %>
-    <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
-    <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
-    <%= link_to "Upgrade #{user.name} to Merchant Employee", "/admin/users/#{user.id}/upgrade_to_merchant_employee" %>
-    <%= link_to "Upgrade #{user.name} to Merchant Admin", "/admin/users/#{user.id}/upgrade_to_merchant_admin" %>
+  <section id='user-<%=user.id%>'>
+    <%= link_to "#{user.name}", "admin/users/#{user.id}" %>
+    Registered: <%= user.created_at %>
+    User Type: <%= user.role %>
+    <% if user.role == "user" %>
+      <%= link_to "Edit #{user.name}'s Profile", "/admin/users/#{user.id}/profile/edit" %>
+      <%= link_to "Edit #{user.name}'s Password", "/admin/users/#{user.id}/password/edit" %>
+      <%= link_to "Upgrade #{user.name} to Merchant Employee", "/admin/users/#{user.id}/upgrade_to_merchant_employee" %>
+      <%= link_to "Upgrade #{user.name} to Merchant Admin", "/admin/users/#{user.id}/upgrade_to_merchant_admin" %>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @users.each do |user| %>
   <section id='user-<%=user.id%>'>
-    <%= link_to "#{user.name}", "/users/#{user.id}" %>
+    <%= link_to "#{user.name}", "/admin/users/#{user.id}" %>
     Registered: <%= user.created_at %>
     User Type: <%= user.role %>
     <% if user.role != "admin" %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,13 +1,42 @@
-<h2><%= @user.name %>'s profile</h2>
+<% if @user.role == "user" %>
+  <h2><%= @user.name %>'s profile</h2>
 
 
-<h2>Name: <%= @user.name %></h2>
-<h2>Address: <%= @user.address %></h2>
-<h2>City: <%= @user.city %></h2>
-<h2>State: <%= @user.state %></h2>
-<h2>Zip: <%= @user.zip %></h2>
-<h2>Email: <%= @user.email %></h2>
+  <h2>Name: <%= @user.name %></h2>
+  <h2>Address: <%= @user.address %></h2>
+  <h2>City: <%= @user.city %></h2>
+  <h2>State: <%= @user.state %></h2>
+  <h2>Zip: <%= @user.zip %></h2>
+  <h2>Email: <%= @user.email %></h2>
 
-<%= link_to "Edit #{@user.name}'s Password", "/admin/users/#{@user.id}/password/edit" %>
-<%= link_to "Upgrade #{@user.name} to Merchant Employee", "/admin/users/#{@user.id}/upgrade_to_merchant_employee" %>
-<%= link_to "Upgrade #{@user.name} to Merchant Admin", "/admin/users/#{@user.id}/upgrade_to_merchant_admin" %>
+  <%= link_to "Edit #{@user.name}'s Password", "/admin/users/#{@user.id}/password/edit" %>
+  <%= link_to "Upgrade #{@user.name} to Merchant Employee", "/admin/users/#{@user.id}/upgrade_to_merchant_employee" %>
+  <%= link_to "Upgrade #{@user.name} to Merchant Admin", "/admin/users/#{@user.id}/upgrade_to_merchant_admin" %>
+<% else %>
+  <% if @user.merchant != nil %>
+    <h1><%= @user.merchant.name %></h1>
+    <p>Address: <%= @user.merchant.address %></p>
+    <p>City: <%= @user.merchant.city %></p>
+    <p>State: <%= @user.merchant.state %></p>
+    <p>Zip: <%= @user.merchant.zip %></p>
+
+  <section id="orders">
+    <h2>Orders:</h2>
+    <% @user.merchant.orders_info.each do |item_order| %>
+      <% if item_order.order.status == "pending" %>
+      <section id="order-<%= item_order.order_id %>">
+        <%= link_to "#{item_order.order_id}", "merchant/orders/#{item_order.order.id}" %>
+        Order Creation Date: <%= item_order.order.created_at.strftime('%m/%d/%y') %>
+        Total Quantity: <%= item_order.total_quantity %>
+        Total Value: <%= number_to_currency(@user.merchant.order_price(item_order.order_id)/100.0) %>
+      </section>
+      <% end %>
+    <% end  %>
+  </section>
+
+  <% else %>
+    <p> You do not currently belong to a merchant in the system. </p>
+  <% end %>
+
+  <%= link_to "View My Items", "/merchant/items" %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -8,7 +8,6 @@
 <h2>Zip: <%= @user.zip %></h2>
 <h2>Email: <%= @user.email %></h2>
 
-<%= link_to "Edit #{@user.name}'s Profile", "/admin/users/#{@user.id}/profile/edit" %>
 <%= link_to "Edit #{@user.name}'s Password", "/admin/users/#{@user.id}/password/edit" %>
 <%= link_to "Upgrade #{@user.name} to Merchant Employee", "/admin/users/#{@user.id}/upgrade_to_merchant_employee" %>
 <%= link_to "Upgrade #{@user.name} to Merchant Admin", "/admin/users/#{@user.id}/upgrade_to_merchant_admin" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
           <%= link_to "Dashboard", "/merchant" %>
         <% elsif current_user.admin? %>
           <%= link_to "Dashboard", "/admin" %>
-          <%= link_to "See All Users", "/admin/users" %>
+          <%= link_to "Users", "/admin/users" %>
         <% end %>
         <%= link_to "Log Out", "/logout", method: :delete %>
         <p>Logged in as <%= current_user.name %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
     patch '/merchants/:merchant_id', to: 'merchants#update'
     get '/merchants/:merchant_id', to: "merchants#show"
     get '/users', to: "users#index"
-    get '/users/:id/profile', to: "users#show"
+    get '/users/:user_id/', to: "users#show"
     get '/users/:user_id/profile/edit', to: "users#edit"
     patch '/users/:user_id/profile', to: "users#update"
     get '/users/:user_id/password/edit', to: "users#edit"

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'admin can perform the same actions that a user can and also chan
       end
 
       expect(current_path).to eq('/admin/users')
-      expect(page).to_not have_content(merchant_admin.name)
 
       within "#user-#{user_1.id}" do
         click_link("Edit #{user_1.name}'s Profile")
@@ -138,15 +137,17 @@ RSpec.describe 'admin can perform the same actions that a user can and also chan
         click_link("Upgrade #{user_1.name} to Merchant Employee")
       end
 
+      user_1.reload
+
       expect(current_path).to eq('/admin/users')
-      expect(page).to_not have_css("#user-#{user_1.id}")
+      expect(user_1.role).to eq("merchant_employee")
 
       within "#user-#{user_2.id}" do
         click_link("Upgrade #{user_2.name} to Merchant Admin")
       end
 
       expect(current_path).to eq('/admin/users')
-      expect(page).to_not have_css("#user-#{user_2.id}")
+      expect(user_2.role).to eq("merchant_admin")
     end
   end
 end

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -146,6 +146,8 @@ RSpec.describe 'admin can perform the same actions that a user can and also chan
         click_link("Upgrade #{user_2.name} to Merchant Admin")
       end
 
+      user_2.reload
+
       expect(current_path).to eq('/admin/users')
       expect(user_2.role).to eq("merchant_admin")
     end

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'admin can perform the same actions that a user can and also chan
       visit '/'
 
       within 'nav' do
-        click_link "See All Users"
+        click_link "Users"
       end
 
       expect(current_path).to eq('/admin/users')

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -3,16 +3,16 @@ require 'rails_helper'
 RSpec.describe "as an admin" do
   before :each do
     @user_1 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
-    @user_2 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user", password_confirmation: "user")
-    @user_3 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user", password_confirmation: "user")
-    @user_4 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user", password_confirmation: "user")
+    @user_2 = User.create!(name: "User Two", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user", password_confirmation: "user")
+    @user_3 = User.create!(name: "User Three", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user", password_confirmation: "user")
+    @user_4 = User.create!(name: "User Four", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user", password_confirmation: "user")
 
     @merchant_employee = User.create!(name: "Merchant Employee", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_employee@merchant_employee.com", password: "merchant_employee", password_confirmation: "merchant_employee", role: 1)
     @merchant_admin = User.create!(name: "Merchant Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_admin@merchant_admin.com", password: "merchant_admin", password_confirmation: "merchant_admin", role: 2)
 
 
     @admin = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin@admin.com", password: "admin", password_confirmation: "admin", role: 3)
-    @admin_2 = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin2@admin.com", password: "admin", password_confirmation: "admin", role: 3)
+    @admin_2 = User.create!(name: "Admin Dos", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin2@admin.com", password: "admin", password_confirmation: "admin", role: 3)
   end
 
   it "I see a users link in the top navbar which brings me to the user index page" do
@@ -40,14 +40,46 @@ RSpec.describe "as an admin" do
 
     expect(page).to have_content("The page you were looking for doesn't exist (404)")
   end
+
+  it "the users index page lists all users (name is link to show page), the date they registered, and the type of user they are" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+    visit '/admin/users'
+
+    within "user-#{@user_1.id}" do
+      expect(page).to have_link(@user_1.name)
+      expect(page).to have_content(@user_1.created_at)
+      expect(page).to have_content(@user_1.role)
+      expect(page).to_not have_content(@user_2.name)
+      expect(page).to_not have_content(@user_3.name)
+      expect(page).to_not have_content(@user_4.name)
+    end
+
+    within "user-#{@user_2.id}" do
+      expect(page).to have_link(@user_2.name)
+      expect(page).to have_content(@user_2.created_at)
+      expect(page).to have_content(@user_2.role)
+      expect(page).to_not have_content(@user_1.name)
+      expect(page).to_not have_content(@user_3.name)
+      expect(page).to_not have_content(@user_4.name)
+    end
+
+    within "user-#{@merchant_admin.id}" do
+      expect(page).to have_link(@merchant_admin.name)
+      expect(page).to have_content(@merchant_admin.created_at)
+      expect(page).to have_content(@merchant_admin.role)
+      expect(page).to_not have_content(@user_1.name)
+      expect(page).to_not have_content(@user_3.name)
+      expect(page).to_not have_content(@user_4.name)
+    end
+
+    within "user-#{@admin_2.id}" do
+      expect(page).to have_link(@admin_2.name)
+      expect(page).to have_content(@admin_2.created_at)
+      expect(page).to have_content(@admin_2.role)
+      expect(page).to_not have_content(@user_1.name)
+      expect(page).to_not have_content(@user_3.name)
+      expect(page).to_not have_content(@user_4.name)
+    end
+  end
 end
-
-
-# As an admin user
-# When I click the "Users" link in the nav (only visible to admins)
-# Then my current URI route is "/admin/users"
-# Only admin users can reach this path.
-# I see all users in the system
-# Each user's name is a link to a show page for that user ("/admin/users/5")
-# Next to each user's name is the date they registered
-# Next to each user's name I see what type of user they are

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "as an admin" do
   before :each do
-    @user_1 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
-    @user_2 = User.create!(name: "User Two", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user", password_confirmation: "user")
-    @user_3 = User.create!(name: "User Three", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user", password_confirmation: "user")
-    @user_4 = User.create!(name: "User Four", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user", password_confirmation: "user")
+    @user_1 = User.create!(name: "Miss Solo", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
+    @user_2 = User.create!(name: "Mr. Two", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user", password_confirmation: "user")
+    @user_3 = User.create!(name: "Senor Three", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user", password_confirmation: "user")
+    @user_4 = User.create!(name: "Mrs. Four", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user", password_confirmation: "user")
 
     @merchant_employee = User.create!(name: "Merchant Employee", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_employee@merchant_employee.com", password: "merchant_employee", password_confirmation: "merchant_employee", role: 1)
     @merchant_admin = User.create!(name: "Merchant Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_admin@merchant_admin.com", password: "merchant_admin", password_confirmation: "merchant_admin", role: 2)
@@ -46,7 +46,7 @@ RSpec.describe "as an admin" do
 
     visit '/admin/users'
 
-    within "user-#{@user_1.id}" do
+    within "#user-#{@user_1.id}" do
       expect(page).to have_link(@user_1.name)
       expect(page).to have_content(@user_1.created_at)
       expect(page).to have_content(@user_1.role)
@@ -55,7 +55,7 @@ RSpec.describe "as an admin" do
       expect(page).to_not have_content(@user_4.name)
     end
 
-    within "user-#{@user_2.id}" do
+    within "#user-#{@user_2.id}" do
       expect(page).to have_link(@user_2.name)
       expect(page).to have_content(@user_2.created_at)
       expect(page).to have_content(@user_2.role)
@@ -64,7 +64,7 @@ RSpec.describe "as an admin" do
       expect(page).to_not have_content(@user_4.name)
     end
 
-    within "user-#{@merchant_admin.id}" do
+    within "#user-#{@merchant_admin.id}" do
       expect(page).to have_link(@merchant_admin.name)
       expect(page).to have_content(@merchant_admin.created_at)
       expect(page).to have_content(@merchant_admin.role)
@@ -73,13 +73,14 @@ RSpec.describe "as an admin" do
       expect(page).to_not have_content(@user_4.name)
     end
 
-    within "user-#{@admin_2.id}" do
+    within "#user-#{@admin_2.id}" do
       expect(page).to have_link(@admin_2.name)
       expect(page).to have_content(@admin_2.created_at)
       expect(page).to have_content(@admin_2.role)
       expect(page).to_not have_content(@user_1.name)
       expect(page).to_not have_content(@user_3.name)
       expect(page).to_not have_content(@user_4.name)
+      expect(page).to_not have_link("Edit #{@admin_2.name}'s Profile")
     end
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "as an admin" do
+  before :each do
+    @user_1 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
+    @user_2 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user2", password_confirmation: "user")
+    @user_3 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user3", password_confirmation: "user")
+    @user_4 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user4", password_confirmation: "user")
+
+    @merchant_employee = User.create!(name: "Merchant Employee", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_employee@merchant_employee.com", password: "merchant_employee", password_confirmation: "merchant_employee", role: 1)
+    @merchant_admin = User.create!(name: "Merchant Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_admin@merchant_admin.com", password: "merchant_admin", password_confirmation: "merchant_admin", role: 2)
+
+
+    @admin = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin@admin.com", password: "admin", password_confirmation: "admin", role: 3)
+    @admin_2 = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin2@admin.com", password: "admin", password_confirmation: "admin", role: 3)
+  end
+
+  it "I see a users link in the top navbar which brings me to the user index page" do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+    visit '/'
+
+    click_link("Users")
+
+    expect(current_path).to eq("/admin/users")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+    visit '/'
+
+    expect(page).to_not have_link("Users")
+
+    visit '/admin/users'
+
+    expect(page).to have_content("The page you were looking for doesn't exist (404)")
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_admin)
+
+    visit '/admin/users'
+
+    expect(page).to have_content("The page you were looking for doesn't exist (404)")
+  end
+end
+
+
+# As an admin user
+# When I click the "Users" link in the nav (only visible to admins)
+# Then my current URI route is "/admin/users"
+# Only admin users can reach this path.
+# I see all users in the system
+# Each user's name is a link to a show page for that user ("/admin/users/5")
+# Next to each user's name is the date they registered
+# Next to each user's name I see what type of user they are

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe "as an admin" do
   before :each do
     @user_1 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
-    @user_2 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user2", password_confirmation: "user")
-    @user_3 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user3", password_confirmation: "user")
-    @user_4 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user4", password_confirmation: "user")
+    @user_2 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user2@user2.com", password: "user", password_confirmation: "user")
+    @user_3 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user3@user3.com", password: "user", password_confirmation: "user")
+    @user_4 = User.create!(name: "User", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user4@user4.com", password: "user", password_confirmation: "user")
 
     @merchant_employee = User.create!(name: "Merchant Employee", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_employee@merchant_employee.com", password: "merchant_employee", password_confirmation: "merchant_employee", role: 1)
     @merchant_admin = User.create!(name: "Merchant Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_admin@merchant_admin.com", password: "merchant_admin", password_confirmation: "merchant_admin", role: 2)

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -7,14 +7,14 @@ require 'rails_helper'
 
 RSpec.describe "as an admin" do
   it "when I visit a user's profile, I see the same info they see but I do not see the edit profile button" do
-    user_1 = User.create!(name: "Miss Solo", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
+    user = User.create!(name: "Miss Solo", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
     merchant_admin = User.create!(name: "Merchant Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_admin@merchant_admin.com", password: "merchant_admin", password_confirmation: "merchant_admin", role: 2)
 
     admin = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin@admin.com", password: "admin", password_confirmation: "admin", role: 3)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
 
-    visit "/admin/users/#{user_1.id}"
+    visit "/admin/users/#{user.id}"
 
     expect(page).to have_content(user.name)
     expect(page).to have_content(user.address)

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -1,0 +1,26 @@
+# As an admin user
+# When I visit a user's profile page ("/admin/users/5")
+# I see the same information the user would see themselves
+# I do not see a link to edit their profile
+
+require 'rails_helper'
+
+RSpec.describe "as an admin" do
+  it "when I visit a user's profile, I see the same info they see but I do not see the edit profile button" do
+    user_1 = User.create!(name: "Miss Solo", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "user@user.com", password: "user", password_confirmation: "user")
+    merchant_admin = User.create!(name: "Merchant Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "merchant_admin@merchant_admin.com", password: "merchant_admin", password_confirmation: "merchant_admin", role: 2)
+
+    admin = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin@admin.com", password: "admin", password_confirmation: "admin", role: 3)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+    visit "/admin/users/#{user_1.id}"
+
+    expect(page).to have_content(user.name)
+    expect(page).to have_content(user.address)
+    expect(page).to have_content(user.city)
+    expect(page).to have_content(user.state)
+    expect(page).to have_content(user.zip)
+    expect(page).to have_content(user.email)
+  end
+end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -24,5 +24,10 @@ RSpec.describe "as an admin" do
     expect(page).to have_content(user.email)
     expect(page).to have_link("Edit #{user.name}'s Password")
     expect(page).to_not have_link("Edit #{user.name}'s Profile")
+
+    visit "/admin/users/#{merchant_admin.id}"
+
+    expect(page).to have_content("You do not currently belong to a merchant in the system.")
+    expect(page).to_not have_content(user.name)
   end
 end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "as an admin" do
 
     admin = User.create!(name: "Admin", address: "1230 East Street", city: "Boulder", state: "CO", zip: 98273, email: "admin@admin.com", password: "admin", password_confirmation: "admin", role: 3)
 
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit "/admin/users/#{user.id}"
 

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -22,5 +22,7 @@ RSpec.describe "as an admin" do
     expect(page).to have_content(user.state)
     expect(page).to have_content(user.zip)
     expect(page).to have_content(user.email)
+    expect(page).to have_link("Edit #{user.name}'s Password")
+    expect(page).to_not have_link("Edit #{user.name}'s Profile")
   end
 end

--- a/spec/features/admins/dashboard_spec.rb
+++ b/spec/features/admins/dashboard_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "admin dashboard" do
       click_on "#{@order_3.name}"
     end
 
-    expect(current_path).to eq("/admin/users/#{@order_3.user.id}/profile")
+    expect(current_path).to eq("/admin/users/#{@order_3.user.id}")
   end
 
   it "has a button next to all packaged orders for the admin to ship the order" do

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Site Navigation' do
       expect(current_path).to eq("/admin")
 
       within 'nav' do
-        click_link "See All Users"
+        click_link "Users"
       end
       expect(current_path).to eq("/admin/users")
 


### PR DESCRIPTION
**New Functionality**
- create admin user index page -- lists all users including admins and merchants.
- create admin view of user show page for user and merchant's (but not for other admins)

**Refactor**
- `change_role` admin user controller action was not pathing through conditional correctly. Updated `request.env['PATH_INFO']` to use path "/admin/users/..."
- Updated User Index link to be titled "Users" instead of "See All Users". Updated previous tests to expect this button
- removed "/profile" from route to get to admin view of user show page (path is now just "/admin/users/id"

**Tests**
- all tests passing 99.81% coverage